### PR TITLE
2.1.0

### DIFF
--- a/src/Api/OrderApi.php
+++ b/src/Api/OrderApi.php
@@ -107,16 +107,95 @@ class OrderApi extends AbstractApi
         return $collection;
     }
 
-    public function getCollection(
+    /**
+     * Tries to find an order by email address, returns null when not found.
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByEmail(string $email): ?Order
+    {
+        $data = $this->handleSingleItemResponse(
+            $this->get('orders', ['email' => $email])
+        );
+
+        return null !== $data ? $this->toEntity($data) : null;
+    }
+
+    /**
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByEmails(
+        array $emails,
         ?int $page = null,
         ?int $perPage = null,
         ?array $order = null
+    ): OrderCollection {
+        $data = $this->get('orders', [
+            'email' => $emails,
+            'page' => $page ?? 1,
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
+        ]);
+
+        $collection = $this->toCollection($data, OrderCollection::class);
+        assert($collection instanceof OrderCollection);
+
+        return $collection;
+    }
+
+    /**
+     * Tries to find an order by email address as set on the linked customer
+     * resource, returns null when not found.
+     *
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerEmail(string $email): ?Order
+    {
+        $data = $this->handleSingleItemResponse(
+            $this->get('orders', ['customer.email' => $email])
+        );
+
+        return null !== $data ? $this->toEntity($data) : null;
+    }
+
+    /**
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerEmails(
+        array $emails,
+        ?int $page = null,
+        ?int $perPage = null,
+        ?array $order = null
+    ): OrderCollection {
+        $data = $this->get('orders', [
+            'customer.email' => $emails,
+            'page' => $page ?? 1,
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
+        ]);
+
+        $collection = $this->toCollection($data, OrderCollection::class);
+        assert($collection instanceof OrderCollection);
+
+        return $collection;
+    }
+
+    public function getCollection(
+        ?int $page = null,
+        ?int $perPage = null,
+        ?array $order = null,
+        ?array $filters = []
     ): OrderCollection {
         $data = $this->get('orders', [
             'page' => $page ?? 1,
             'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
             'order' => $order ?? self::DEFAULT_ORDER
         ]);
+
+        if (count($filters) > 0) {
+            foreach ($filters as $key => $value) {
+                $data[$key] = $value;
+            }
+        }
 
         $collection = $this->toCollection($data, OrderCollection::class);
         assert($collection instanceof OrderCollection);

--- a/src/Api/OrderApi.php
+++ b/src/Api/OrderApi.php
@@ -72,6 +72,41 @@ class OrderApi extends AbstractApi
         return $collection;
     }
 
+    /**
+     * Tries to find an order by customer reference, returns null when not found.
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerRef(string $ref): ?Order
+    {
+        $data = $this->handleSingleItemResponse(
+            $this->get('orders', ['customer_ref' => $ref])
+        );
+
+        return null !== $data ? $this->toEntity($data) : null;
+    }
+
+    /**
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerRefs(
+        array $refs,
+        ?int $page = null,
+        ?int $perPage = null,
+        ?array $order = null
+    ): OrderCollection {
+        $data = $this->get('orders', [
+            'customer_ref' => $refs,
+            'page' => $page ?? 1,
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
+        ]);
+
+        $collection = $this->toCollection($data, OrderCollection::class);
+        assert($collection instanceof OrderCollection);
+
+        return $collection;
+    }
+
     public function getCollection(
         ?int $page = null,
         ?int $perPage = null,

--- a/src/Api/QuoteApi.php
+++ b/src/Api/QuoteApi.php
@@ -12,6 +12,16 @@ use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExcep
 
 class QuoteApi extends AbstractApi
 {
+    public const ORDERABLE_PARAMS = [
+        'quote_id',
+        'created_at',
+        'updated_at'
+    ];
+
+    public const DEFAULT_ORDER = [
+        'created_at' => 'desc'
+    ];
+
     public function create(Quote|EntityInterface $entity): Quote
     {
         assert($entity instanceof Quote);
@@ -50,6 +60,41 @@ class QuoteApi extends AbstractApi
             'quote_ref' => $refs,
             'page' => $page ?? 1,
             'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE
+        ]);
+
+        $collection = $this->toCollection($data, QuoteCollection::class);
+        assert($collection instanceof QuoteCollection);
+
+        return $collection;
+    }
+
+    /**
+     * Tries to find a quote by customer reference, returns null when not found.
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerRef(string $ref): ?Quote
+    {
+        $data = $this->handleSingleItemResponse(
+            $this->get('quotes', ['customer_ref' => $ref])
+        );
+
+        return null !== $data ? $this->toEntity($data) : null;
+    }
+
+    /**
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerRefs(
+        array $refs,
+        ?int $page = null,
+        ?int $perPage = null,
+        ?array $order = null
+    ): QuoteCollection {
+        $data = $this->get('quotes', [
+            'customer_ref' => $refs,
+            'page' => $page ?? 1,
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
         ]);
 
         $collection = $this->toCollection($data, QuoteCollection::class);

--- a/src/Api/QuoteApi.php
+++ b/src/Api/QuoteApi.php
@@ -104,17 +104,56 @@ class QuoteApi extends AbstractApi
     }
 
     /**
+     * Tries to find a quote by email address as set on the linked customer
+     * resource, returns null when not found.
+     *
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerEmail(string $email): ?Quote
+    {
+        $data = $this->handleSingleItemResponse(
+            $this->get('quotes', ['customer.email' => $email])
+        );
+
+        return null !== $data ? $this->toEntity($data) : null;
+    }
+
+    /**
+     * @throws HttpClientExceptionInterface
+     */
+    public function getByCustomerEmails(
+        array $emails,
+        ?int $page = null,
+        ?int $perPage = null,
+        ?array $order = null
+    ): QuoteCollection {
+        $data = $this->get('quotes', [
+            'customer.email' => $emails,
+            'page' => $page ?? 1,
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
+        ]);
+
+        $collection = $this->toCollection($data, QuoteCollection::class);
+        assert($collection instanceof QuoteCollection);
+
+        return $collection;
+    }
+
+    /**
      * {@inheritDoc}
      * @param array $filters Optional filters.
      */
     public function getCollection(
         ?int $page = null,
         ?int $perPage = null,
-        $filters = []
+        ?array $filters = [],
+        ?array $order = null
     ): QuoteCollection {
         $params = [
             'page' => $page ?? 1,
-            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE
+            'itemsPerPage' => $perPage ?? self::DEFAULT_ITEMS_PER_PAGE,
+            'order' => $order ?? self::DEFAULT_ORDER
         ];
 
         if (count($filters) > 0) {


### PR DESCRIPTION
Added features:
- Retrieve orders and quotes by customer reference(s) using `->getByCustomerRef('example_ref')` and `->getByCustomerRefs(['example_ref_1', 'example_ref_2'])`
- Retrieve orders and quotes by email address(es) as set on the **linked customer** using `->getByCustomerEmail('example@domain.com')` and `->getByCustomerEmails(['example1@domain.com', 'example2@domain.com'])`
- Retrieve orders by email address(es) as set on the order itself by using: `->getByEmail('example@domain.com')` and `->getByEmails(['example1@domain.com', 'example2@domain.com'])`
- Quotes can now be ordered (sorted) on